### PR TITLE
feat: add gh command and neovim

### DIFF
--- a/home-manager/atolycs@atlas/home.nix
+++ b/home-manager/atolycs@atlas/home.nix
@@ -14,7 +14,6 @@
     outputs.homeModules.desktop-manager.gdm
     outputs.homeModules.avatar
     outputs.homeModules.programs.gh
-    outputs.homeModules.programs.vscode
     outputs.homeModules.programs.nvim
   ];
 

--- a/home-manager/atolycs@atlas/home.nix
+++ b/home-manager/atolycs@atlas/home.nix
@@ -13,6 +13,9 @@
     outputs.homeModules.pkgs
     outputs.homeModules.desktop-manager.gdm
     outputs.homeModules.avatar
+    outputs.homeModules.programs.gh
+    outputs.homeModules.programs.vscode
+    outputs.homeModules.programs.nvim
   ];
 
   home = {

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -3,4 +3,5 @@
   pkgs = import ./pkgs;
   desktop-manager = import ./desktop-manager;
   avatar = import ./avatar;
+  programs = import ./programs;
 }

--- a/modules/home-manager/programs/default.nix
+++ b/modules/home-manager/programs/default.nix
@@ -1,0 +1,5 @@
+{
+  vscode = import ./vscode.nix;
+  nvim = import ./nvim.nix;
+  gh = import ./gh.nix;
+}

--- a/modules/home-manager/programs/gh.nix
+++ b/modules/home-manager/programs/gh.nix
@@ -1,0 +1,10 @@
+{pkgs, ...}: {
+  config = {
+    programs = {
+      gh = {
+        enable = true;
+        package = pkgs.gh;
+      };
+    };
+  };
+}

--- a/modules/home-manager/programs/nvim.nix
+++ b/modules/home-manager/programs/nvim.nix
@@ -1,0 +1,9 @@
+{
+  config = {
+    programs = {
+      neovim = {
+      enable = true;
+    };
+    };
+  };
+}

--- a/modules/home-manager/programs/vscode.nix
+++ b/modules/home-manager/programs/vscode.nix
@@ -1,0 +1,8 @@
+{ pkgs,... }: {
+  config = {
+    programs.vscode = { 
+      enable = true;
+      package = pkgs.vscode.fhs;
+    };
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@
         sha256 = lock.narHash;
       };
     in
-    import nixpkgs { overlays = [ ]; },
+    import nixpkgs { config.allowUnfree = true; overlays = [ ]; },
   ...
 }@inputs:
 let
@@ -20,6 +20,9 @@ let
     '')
     (pkgs.writeScriptBin "switch-home" ''
       home-manager switch --flake ".#$@" --show-trace
+    '')
+    (pkgs.writeScriptBin "update-home" ''
+      home-manager switch --flake "." --show-trace $@
     '')
   ];
 in
@@ -46,6 +49,7 @@ pkgs.stdenv.mkDerivation {
   shellHook = ''
     source ${pkgs.git}/share/bash-completion/completions/git-prompt.sh;
     export PROMPT_DIRTRIM=2;
+    export NIXPKGS_ALLOW_UNFREE=1;
     export PS1='\n\[\033[1;32m\][devShell is \[\033[0;33m\]$(echo $name)\[\033[1;32m\]:\w]$(__git_ps1 "(%s)")\$\[\033[0m\] '
   '';
 


### PR DESCRIPTION
This pull request includes several changes to the `home-manager` configuration to add new programs and enable specific settings. The most important changes include the addition of new program modules, updates to the home configuration, and modifications to the `shell.nix` file to allow unfree packages and add a new script.

### Addition of new program modules:

* [`modules/home-manager/programs/default.nix`](diffhunk://#diff-c12e3a08d1b49a36ada2eacda5c4a3b8dfc3748b22316a33e86feebd49618239R1-R5): Added imports for `vscode.nix`, `nvim.nix`, and `gh.nix` to include new program modules.
* [`modules/home-manager/programs/gh.nix`](diffhunk://#diff-dfc419eb234e52855cab1ecc2aba1101e331112f9b5098ee29d68d7860363de3R1-R10): Added configuration to enable the `gh` program and set its package.
* [`modules/home-manager/programs/nvim.nix`](diffhunk://#diff-38854ad9fa5747bd16c7288212f24e5115e4fc30c5fd73e51db4b1529e8b7409R1-R9): Added configuration to enable the `neovim` program.
* [`modules/home-manager/programs/vscode.nix`](diffhunk://#diff-2c8eca62485c7220cfef82202b1ff1a4d30a2e17c6249b1aa8302a073b9529b1R1-R8): Added configuration to enable the `vscode` program and set its package.

### Updates to home configuration:

* [`home-manager/atolycs@atlas/home.nix`](diffhunk://#diff-74736a01c0f4ed22830b5c796d66a7a4a5fbc8b1ca9a97e5573a2d33f1b8f1b3R16-R17): Added `outputs.homeModules.programs.gh` and `outputs.homeModules.programs.nvim` to the list of home modules.
* [`modules/home-manager/default.nix`](diffhunk://#diff-ebde84352994735f8d5f618942f48306092faafe114447d6c385735b6ef63993R6): Added `programs` import to include the new program modules in the home manager.

### Modifications to `shell.nix`:

* [`shell.nix`](diffhunk://#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6bL10-R10): Enabled unfree packages by setting `config.allowUnfree = true` and added a new script `update-home` for updating the home configuration. [[1]](diffhunk://#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6bL10-R10) [[2]](diffhunk://#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6bR24-R26)
* [`shell.nix`](diffhunk://#diff-e53dfbfffe62ae3c0b411b3938ccffa9fb6a2ecc565f55785ef8daa756631a6bR52): Added `NIXPKGS_ALLOW_UNFREE=1` to the `shellHook` to allow unfree packages in the development shell.