### PR TITLE
Dev/hosts configuration

### DIFF
--- a/base-profiles/minimal-gui/default.nix
+++ b/base-profiles/minimal-gui/default.nix
@@ -2,5 +2,6 @@
 {
   imports = [
     outputs.nixosModules.desktop-profiles.gnome
+    outputs.nixosModules.programs.vim
   ];
 }

--- a/modules/nixos/pkgs/default.nix
+++ b/modules/nixos/pkgs/default.nix
@@ -1,0 +1,7 @@
+{ pkgs, ... }:
+let
+  global = import ./global.nix { inherit pkgs; };
+in
+{
+  environment.systemPackages = [ ] ++ global;
+}

--- a/modules/nixos/programs/default.nix
+++ b/modules/nixos/programs/default.nix
@@ -1,4 +1,5 @@
 {
   git = import ./git;
   firefox-esr = import ./firefox-esr;
+  vim = import ./vim;
 }

--- a/modules/nixos/programs/vim/default.nix
+++ b/modules/nixos/programs/vim/default.nix
@@ -1,5 +1,5 @@
 { ... }: {
   config = {
-    programs.vim = true;
-  }
+    programs.vim.enable = true;
+  };
 }

--- a/modules/nixos/programs/vim/default.nix
+++ b/modules/nixos/programs/vim/default.nix
@@ -1,0 +1,5 @@
+{ ... }: {
+  config = {
+    programs.vim = true;
+  }
+}


### PR DESCRIPTION
This pull request includes changes to add Vim as a system package and enable it in the configuration. The most important changes include importing Vim in various configuration files and enabling Vim in the NixOS configuration.

Changes to add and enable Vim:

* [`base-profiles/minimal-gui/default.nix`](diffhunk://#diff-5a9cc879f97c66ca3278be2601a0e468b34d18f81b2dce58cb2b06378c8204acR5): Added `outputs.nixosModules.programs.vim` to the imports.
* [`modules/nixos/pkgs/default.nix`](diffhunk://#diff-b0ec870a941075c25bb86d8040b78b339b1f7c722bc60dba3d526aa34943f7d3R1-R7): Imported global configuration and included it in `environment.systemPackages`.
* [`modules/nixos/programs/default.nix`](diffhunk://#diff-93da5b2fd7a0d00d387728b3040dde3d7ed85b9475bb08dc754629aa16f72afaR4): Added Vim to the list of imported programs.
* [`modules/nixos/programs/vim/default.nix`](diffhunk://#diff-c106fa543199ba0b4c72caa8cefb0075b098a64ffcc3c61c4f48fb9ae9f69b52R1-R5): Enabled Vim in the configuration.