### PR TITLE
Dev/gnome extension dconf

### DIFF
--- a/home-manager/atolycs@nahida/home.nix
+++ b/home-manager/atolycs@nahida/home.nix
@@ -30,6 +30,9 @@
     ];
 
     dconf = {
+      "org/gnome/desktop/interface" = {
+        accent-color = "#6b932f";
+      };
       "org/gnome/shell/extensions/openbar" = {
          bartype = "Trilands";
 	 reloadstyle = true;

--- a/home-manager/atolycs@nahida/home.nix
+++ b/home-manager/atolycs@nahida/home.nix
@@ -34,8 +34,8 @@
         accent-color = "#6b932f";
       };
       "org/gnome/shell/extensions/openbar" = {
-         bartype = "Trilands";
-	 reloadstyle = true;
+        bartype = "Trilands";
+        reloadstyle = true;
       };
     };
   };

--- a/home-manager/atolycs@nahida/home.nix
+++ b/home-manager/atolycs@nahida/home.nix
@@ -5,6 +5,7 @@
   outputs,
   self,
   stateVersion,
+  pkgs,
   ...
 }:
 {
@@ -18,6 +19,23 @@
 
     outputs.homeModules.hosts.nahida
   ];
+
+  desktop-manager.gdm = {
+    packages = with pkgs; [
+      gnomeExtensions.open-bar
+    ];
+
+    enable-plugins = with pkgs; [
+      gnomeExtensions.open-bar.extensionUuid
+    ];
+
+    dconf = {
+      "org/gnome/shell/extensions/openbar" = {
+         bartype = "Trilands";
+	 reloadstyle = true;
+      };
+    };
+  };
 
   home = {
     username = "atolycs";

--- a/modules/home-manager/desktop-manager/gdm/default.nix
+++ b/modules/home-manager/desktop-manager/gdm/default.nix
@@ -17,6 +17,7 @@ let
   ];
 in
 with lib.hm.gvariant;
+with lib;
 {
 
   imports = [
@@ -62,7 +63,7 @@ with lib.hm.gvariant;
 
     dconf = {
       enable = true;
-      settings = {
+      settings = lib.recursiveUpdate ({
         "org/gnome/desktop/wm/preferences" = {
           button-layout = "appmenu:minimize,maximize,close";
         };
@@ -118,7 +119,7 @@ with lib.hm.gvariant;
         "org/gnome/nautilus/icon-view" = {
           default-zoom-level = "small-plus";
         };
-      } // cfg.dconf;
+      }) cfg.dconf;
     };
   };
 }

--- a/modules/home-manager/desktop-manager/gdm/default.nix
+++ b/modules/home-manager/desktop-manager/gdm/default.nix
@@ -36,6 +36,12 @@ with lib.hm.gvariant;
         default = [ ];
         description = "Enable plugin list";
       };
+
+      dconf = lib.mkOption {
+        type = lib.types.nullOr (lib.types.attrs);
+        default = { };
+        description = "Additional dconf";
+      };
     };
   };
 
@@ -112,7 +118,7 @@ with lib.hm.gvariant;
         "org/gnome/nautilus/icon-view" = {
           default-zoom-level = "small-plus";
         };
-      };
+      } // cfg.dconf;
     };
   };
 }

--- a/modules/home-manager/hosts/nahida/default.nix
+++ b/modules/home-manager/hosts/nahida/default.nix
@@ -4,17 +4,31 @@
   config,
   ...
 }:
+let
+  cfg = config.desktop-manager;
+
+in
 with lib.hm.gvariant;
 {
+  # options = {
+  #   sync-wallpaper = {
+  #      type = lib.types.bool;
+  #      default = false;
+  #      description = "Sync colorscheme wallpaper";
+  #   };
+  # };
+  # config = {
   home.file = {
     ".wallpaper/nahida.webp" = {
       source = ./nahida.webp;
     };
   };
 
-  dconf.settings = {
+  dconf.settings = { } // {
     "org/gnome/desktop/background" = {
       picture-uri = mkString "file://${config.home.homeDirectory}/.wallpaper/nahida.webp";
+      picture-uri-dark = mkString "file://${config.home.homeDirectory}/.wallpaper/nahida.webp";
     };
   };
+  # };
 }


### PR DESCRIPTION
This pull request introduces several changes to the configuration and management of the GNOME desktop environment using Nix. The key updates include adding support for additional dconf settings, configuring GNOME extensions, and improving the modularity of the configuration files.

### Configuration improvements:

* [`home-manager/atolycs@nahida/home.nix`](diffhunk://#diff-309598c6638c5b93717042be7906a67314e754dfd7645d7df75b0c146d750489R8): Added the `pkgs` parameter and configured the `desktop-manager.gdm` with new packages and dconf settings for GNOME extensions. [[1]](diffhunk://#diff-309598c6638c5b93717042be7906a67314e754dfd7645d7df75b0c146d750489R8) [[2]](diffhunk://#diff-309598c6638c5b93717042be7906a67314e754dfd7645d7df75b0c146d750489R23-R42)

### Enhancements to GNOME desktop management:

* [`modules/home-manager/desktop-manager/gdm/default.nix`](diffhunk://#diff-0cdccfa5f8e14bf693106ec0a64cd0698386024f948bf3951ec6939ae06b4174R40-R45): Introduced a new `dconf` option for additional configuration, and updated the `settings` attribute to use `lib.recursiveUpdate` for merging settings. [[1]](diffhunk://#diff-0cdccfa5f8e14bf693106ec0a64cd0698386024f948bf3951ec6939ae06b4174R40-R45) [[2]](diffhunk://#diff-0cdccfa5f8e14bf693106ec0a64cd0698386024f948bf3951ec6939ae06b4174L59-R66) [[3]](diffhunk://#diff-0cdccfa5f8e14bf693106ec0a64cd0698386024f948bf3951ec6939ae06b4174L115-R122)

### Codebase modularity:

* [`modules/home-manager/desktop-manager/gdm/default.nix`](diffhunk://#diff-0cdccfa5f8e14bf693106ec0a64cd0698386024f948bf3951ec6939ae06b4174R20): Added `with lib;` to improve readability and modularity.

### Host-specific configuration:

* [`modules/home-manager/hosts/nahida/default.nix`](diffhunk://#diff-1dff5daac84448f7c0565cfb64c205e7a704a3e258623f819c4e47f81ec78dffR7-R33): Introduced a `let` binding for `cfg` and updated the `dconf.settings` to include a dark mode picture URI for the wallpaper.